### PR TITLE
fix: race condition with multiple drives

### DIFF
--- a/cmd/bernard/devstore/devstore.go
+++ b/cmd/bernard/devstore/devstore.go
@@ -35,11 +35,11 @@ func New(path string) (*Devstore, error) {
 }
 
 // CreateSnapshot returns a *Snapshot of the current state of the datastore.
-func (store *Devstore) CreateSnapshot() (*Snapshot, error) {
+func (store *Devstore) CreateSnapshot(driveID string) (*Snapshot, error) {
 	var files []ds.File
 	var folders []ds.Folder
 
-	fileRows, err := store.DB.Query(sqlSelectFiles)
+	fileRows, err := store.DB.Query(sqlSelectFiles, driveID)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (store *Devstore) CreateSnapshot() (*Snapshot, error) {
 		return nil, err
 	}
 
-	folderRows, err := store.DB.Query(sqlSelectFolders)
+	folderRows, err := store.DB.Query(sqlSelectFolders, driveID)
 	if err != nil {
 		return nil, err
 	}
@@ -90,12 +90,13 @@ func (store *Devstore) CreateSnapshot() (*Snapshot, error) {
 const sqlSelectFolders = `
 SELECT id, name, trashed, parent
 FROM folder
-WHERE parent IS NOT NULL
+WHERE drive=? AND parent IS NOT NULL
 ORDER BY id ASC
 `
 
 const sqlSelectFiles = `
 SELECT id, name, parent, size, md5, trashed
 FROM file
+WHERE drive=?
 ORDER BY id ASC
 `

--- a/cmd/bernard/main.go
+++ b/cmd/bernard/main.go
@@ -73,10 +73,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	if fullSync {
-		os.Remove("./bernard.db")
-	}
-
 	store, err := devstore.New("./bernard.db")
 	if err != nil {
 		panic(err)
@@ -109,7 +105,7 @@ func main() {
 	}
 
 	fmt.Printf("%slog%s - Creating screenshot of the old state\n", colourMagenta, colourReset)
-	oldState, err := store.CreateSnapshot()
+	oldState, err := store.CreateSnapshot(driveID)
 	if err != nil {
 		panic(err) // no error should occur here
 	}
@@ -130,7 +126,7 @@ func main() {
 
 	fmt.Printf("%slog%s - Creating snapshot of the new state\n\n", colourMagenta, colourReset)
 
-	newState, err := store.CreateSnapshot()
+	newState, err := store.CreateSnapshot(driveID)
 	if err != nil {
 		panic(err) // no error should occur here
 	}
@@ -159,7 +155,7 @@ func main() {
 		}
 
 		fmt.Printf("%slog%s - Creating reference snapshot\n", colourMagenta, colourReset)
-		referenceState, err := memStore.CreateSnapshot()
+		referenceState, err := memStore.CreateSnapshot(driveID)
 		if err != nil {
 			panic(err) // no error should occur here
 		}

--- a/datastore/sqlite/hook.go
+++ b/datastore/sqlite/hook.go
@@ -40,7 +40,7 @@ func (store *Datastore) NewDifferencesHook() (bernard.Hook, *Difference) {
 
 		for _, folder := range folders {
 			f := ds.Folder{ID: folder.ID}
-			row := getFolder.QueryRow(folder.ID)
+			row := getFolder.QueryRow(folder.ID, drive.ID)
 			err := row.Scan(&f.Name, &f.Parent, &f.Trashed)
 			if err != nil {
 				// If no row is returned, the folder does not yet exist in the old state.
@@ -70,7 +70,7 @@ func (store *Datastore) NewDifferencesHook() (bernard.Hook, *Difference) {
 
 		for _, file := range files {
 			f := ds.File{ID: file.ID}
-			row := getFile.QueryRow(file.ID)
+			row := getFile.QueryRow(file.ID, drive.ID)
 			err := row.Scan(&f.Name, &f.Parent, &f.Trashed, &f.Size, &f.MD5)
 			if err != nil {
 				// If no row is returned, the file does not yet exist in the old state.
@@ -93,7 +93,7 @@ func (store *Datastore) NewDifferencesHook() (bernard.Hook, *Difference) {
 		for _, id := range removed {
 			// check whether it could be a file first
 			file := ds.File{ID: id}
-			fileRow := getFile.QueryRow(id)
+			fileRow := getFile.QueryRow(id, drive.ID)
 			err := fileRow.Scan(&file.Name, &file.Parent, &file.Trashed, &file.Size, &file.MD5)
 
 			// no error -> thus a file
@@ -108,7 +108,7 @@ func (store *Datastore) NewDifferencesHook() (bernard.Hook, *Difference) {
 
 			// file did not return, try again for folder
 			folder := ds.Folder{ID: id}
-			folderRow := getFolder.QueryRow(id)
+			folderRow := getFolder.QueryRow(id, drive.ID)
 			err = folderRow.Scan(&folder.Name, &folder.Parent, &folder.Trashed)
 
 			// no error -> thus a folder
@@ -133,9 +133,9 @@ func (store *Datastore) NewDifferencesHook() (bernard.Hook, *Difference) {
 }
 
 const sqlGetFileByID = `
-SELECT name, parent, trashed, size, md5 FROM file WHERE id=?
+SELECT name, parent, trashed, size, md5 FROM file WHERE id=? AND drive=?
 `
 
 const sqlGetFolderByID = `
-SELECT name, parent, trashed FROM folder WHERE id=?
+SELECT name, parent, trashed FROM folder WHERE id=? AND drive=?
 `

--- a/datastore/sqlite/hook_test.go
+++ b/datastore/sqlite/hook_test.go
@@ -144,6 +144,7 @@ func TestDifferenceHook(t *testing.T) {
 				},
 			},
 			changes: Changes{
+				drive:   drive,
 				removed: []string{"A", "B", "Z", "Y", "X"},
 			},
 			expected: &Difference{

--- a/datastore/sqlite/sqlite_test.go
+++ b/datastore/sqlite/sqlite_test.go
@@ -98,6 +98,11 @@ func TestAddParameters(t *testing.T) {
 			items:  1,
 			result: "?",
 		},
+		{
+			query:  "DELETE FROM file WHERE id IN (?) AND drive=?",
+			items:  5,
+			result: "DELETE FROM file WHERE id IN (?, ?, ?, ?, ?) AND drive=?",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Out-of-order partial syncs across multiple drives resulted in data loss.


Changes made:
- Added 'drive' column to the datastore to separate files from other drives.
- Primary key now exists of both the file and drive ID.
- Database file no longer deleted on full sync.

### Explaining the issue
When drive A and B both exist in the same database, partial syncs could result in data loss.

In this example the PartialSync() function is first called for drive A, then for drive B.
Now, if folder X moves from A to B, the following happens:

1. Drive A is scanned, marks X as removed
2. Drive B is scanned, marks X as added.

So first X is removed and then it is added again but now belonging to another drive.
The issue occurs when you try to reverse the transfer:

Folder X moves from B to A:
1. Drive A is scanned, marks X as added
2. Drive B is scanned, marks X as removed

Now, the datastore first processes the added files, but removes them right afterwards!
This behaviour directly results in data loss.

### Fixing the issue
To fix the issue, multiple database files can be used so PartialSyncs do not affect each other.
However, this is a SQLite-only solution and I really want to bring support for PostgreSQL and CockroachDB in the near future.

So to fix the issue with multiple databases in mind, I added the `drive` column to both the File and Folder tables, marking the DriveID to which the rows belong. To illustrate how this column fixes the behaviour, allow me to give another example.
This example again uses drives A and B and moving folder X from one to the other.

Folder X moves from A to B:
1. Drive A is scanned, marks X as removed
2. No copies of folder X exist in the datastore at this point in time
3. Drive B is scanned, marks X as added
4. Folder X is added to the datastore with drive-column B

Folder X moves from B to A:
1. Drive A is scanned, marks X as added
2. Two copies of folder X exist in the datastore at this point in time, drive-columns A and B
3. Drive B is scanned, marks X as removed
4. Only one copy of folder X is left in the datastore with drive-column A