### PR TITLE
feat: exponential backoff

### DIFF
--- a/bernard.go
+++ b/bernard.go
@@ -2,6 +2,8 @@ package bernard
 
 import (
 	"errors"
+	"net/http"
+	"time"
 
 	ds "github.com/m-rots/bernard/datastore"
 )
@@ -13,8 +15,8 @@ type Authenticator interface {
 
 // Bernard is a synchronisation backend for Google Drive.
 type Bernard struct {
-	fetch   fetcher
 	driveID string
+	fetch   fetcher
 	store   ds.Datastore
 }
 
@@ -25,7 +27,11 @@ func New(driveID string, auth Authenticator, store ds.Datastore) *Bernard {
 	fetch := fetcher{
 		auth:    auth,
 		baseURL: baseURL,
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+		},
 		driveID: driveID,
+		sleep:   time.Sleep,
 	}
 
 	return &Bernard{

--- a/testdata/drive/basic.json
+++ b/testdata/drive/basic.json
@@ -1,0 +1,3 @@
+{
+  "name": "Coolest Drive on Earth"
+}

--- a/testdata/errors/400/badRequest.json
+++ b/testdata/errors/400/badRequest.json
@@ -1,0 +1,15 @@
+{
+  "error": {
+    "code": 400,
+    "errors": [
+      {
+        "domain": "global",
+        "location": "orderBy",
+        "locationType": "parameter",
+        "message": "Sorting is not supported for queries with fullText terms. Results are always in descending relevance order.",
+        "reason": "badRequest"
+      }
+    ],
+    "message": "Sorting is not supported for queries with fullText terms. Results are always in descending relevance order."
+  }
+}

--- a/testdata/errors/400/invalidSharingRequest.json
+++ b/testdata/errors/400/invalidSharingRequest.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "errors": [
+      {
+        "domain": "global",
+        "reason": "invalidSharingRequest",
+        "message": "Bad Request. User message: \"Sorry, the items were successfully shared but emails could not be sent to email@domain.com.\""
+      }
+    ],
+    "code": 400,
+    "message": "Bad Request"
+  }
+}

--- a/testdata/errors/401/authError.json
+++ b/testdata/errors/401/authError.json
@@ -1,0 +1,15 @@
+{
+  "error": {
+    "errors": [
+      {
+        "domain": "global",
+        "reason": "authError",
+        "message": "Invalid Credentials",
+        "locationType": "header",
+        "location": "Authorization"
+      }
+    ],
+    "code": 401,
+    "message": "Invalid Credentials"
+  }
+}

--- a/testdata/errors/403/appNotAuthorizedToFile.json
+++ b/testdata/errors/403/appNotAuthorizedToFile.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "errors": [
+      {
+        "domain": "global",
+        "reason": "appNotAuthorizedToFile",
+        "message": "The user has not granted the app {appId} {verb} access to the file {fileId}."
+      }
+    ],
+    "code": 403,
+    "message": "The user has not granted the app {appId} {verb} access to the file {fileId}."
+  }
+}

--- a/testdata/errors/403/dailyLimitExceeded.json
+++ b/testdata/errors/403/dailyLimitExceeded.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "errors": [
+      {
+        "domain": "usageLimits",
+        "reason": "dailyLimitExceeded",
+        "message": "Daily Limit Exceeded"
+      }
+    ],
+    "code": 403,
+    "message": "Daily Limit Exceeded"
+  }
+}

--- a/testdata/errors/403/domainPolicy.json
+++ b/testdata/errors/403/domainPolicy.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "errors": [
+      {
+        "domain": "global",
+        "reason": "domainPolicy",
+        "message": "The domain administrators have disabled Drive apps."
+      }
+    ],
+    "code": 403,
+    "message": "The domain administrators have disabled Drive apps."
+  }
+}

--- a/testdata/errors/403/insufficientFilePermissions.json
+++ b/testdata/errors/403/insufficientFilePermissions.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "errors": [
+      {
+        "domain": "global",
+        "reason": "insufficientFilePermissions",
+        "message": "The user does not have sufficient permissions for file {fileId}."
+      }
+    ],
+    "code": 403,
+    "message": "The user does not have sufficient permissions for file {fileId}."
+  }
+}

--- a/testdata/errors/403/rateLimitExceeded.json
+++ b/testdata/errors/403/rateLimitExceeded.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+   "errors": [
+    {
+     "domain": "usageLimits",
+     "message": "Rate Limit Exceeded",
+     "reason": "rateLimitExceeded"
+    }
+   ],
+   "code": 403,
+   "message": "Rate Limit Exceeded"
+  }
+ }

--- a/testdata/errors/403/sharingRateLimitExceeded.json
+++ b/testdata/errors/403/sharingRateLimitExceeded.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+   "errors": [
+    {
+     "domain": "global",
+     "message": "Rate limit exceeded. User message: \"These item(s) could not be shared because a rate limit was exceeded: filename",
+     "reason": "sharingRateLimitExceeded"
+    }
+   ],
+   "code": 403,
+   "message": "Rate Limit Exceeded"
+  }
+ }

--- a/testdata/errors/403/userRateLimitExceeded.json
+++ b/testdata/errors/403/userRateLimitExceeded.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+   "errors": [
+    {
+     "domain": "usageLimits",
+     "reason": "userRateLimitExceeded",
+     "message": "User Rate Limit Exceeded"
+    }
+   ],
+   "code": 403,
+   "message": "User Rate Limit Exceeded"
+  }
+ }

--- a/testdata/errors/404/notFound.json
+++ b/testdata/errors/404/notFound.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "errors": [
+      {
+        "domain": "global",
+        "reason": "notFound",
+        "message": "File not found {fileId}"
+      }
+    ],
+    "code": 404,
+    "message": "File not found: {fileId}"
+  }
+}

--- a/testdata/errors/429/rateLimitExceeded.json
+++ b/testdata/errors/429/rateLimitExceeded.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "errors": [
+      {
+        "domain": "usageLimits",
+        "reason": "rateLimitExceeded",
+        "message": "Rate Limit Exceeded"
+      }
+    ],
+    "code": 429,
+    "message": "Rate Limit Exceeded"
+  }
+}

--- a/testdata/errors/500/backendError.json
+++ b/testdata/errors/500/backendError.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+   "errors": [
+    {
+     "domain": "global",
+     "reason": "backendError",
+     "message": "Backend Error"
+    }
+   ],
+   "code": 500,
+   "message": "Backend Error"
+  }
+ }

--- a/testdata/page-token/basic.json
+++ b/testdata/page-token/basic.json
@@ -1,0 +1,3 @@
+{
+  "startPageToken": "100"
+}


### PR DESCRIPTION
The new fetch architecture as described in #6 has been implemented, with an exponential backoff for the retries as described in #4.

Furthermore, all possible [Google Drive errors](https://developers.google.com/drive/api/v3/handle-errors) (of which the JSON files have been provided) are now part of the test suite. I expect these errors to come in handy at a later date (part of V1) to provide the dependant with a custom error which can be compared. Until then, the error messages are now part of the error response.

One thing which has not yet been implemented is the pre-request hook. Instead, this will come as part of #7 to not break the API with this pull request.

Closes #4 and closes #6.