### PR TITLE
Options pattern

### DIFF
--- a/cmd/bernard/main.go
+++ b/cmd/bernard/main.go
@@ -83,12 +83,12 @@ func main() {
 		"https://www.googleapis.com/auth/iam",
 	})
 
-	bernard := lowe.New(driveID, auth, store)
+	bernard := lowe.New(auth, store)
 
 	if fullSync {
 		fmt.Printf("%slog%s - Starting full sync for the first time\n", colourMagenta, colourReset)
 		fmt.Println("A full sync takes about 1-2 seconds for every 1000 files. This could take a while...")
-		err = bernard.FullSync()
+		err = bernard.FullSync(driveID)
 		if err != nil {
 			if errors.Is(err, ds.ErrDataAnomaly) {
 				fmt.Printf("\n%swarning%s - A data anomaly occured.\n", colourYellow, colourReset)
@@ -113,7 +113,7 @@ func main() {
 	fmt.Printf("%slog%s - Syncing changes from Google Drive\n", colourMagenta, colourReset)
 
 	hook, diff := store.NewDifferencesHook()
-	err = bernard.PartialSync(hook)
+	err = bernard.PartialSync(driveID, hook)
 	if err != nil {
 		if errors.Is(err, ds.ErrDataAnomaly) {
 			fmt.Printf("\n%swarning%s - A data anomaly occured. Please try again in 30 seconds.\n", colourYellow, colourReset)
@@ -141,8 +141,8 @@ func main() {
 		}
 
 		fmt.Printf("%slog%s - Running full sync to act as reference state\n", colourMagenta, colourReset)
-		reference := lowe.New(driveID, auth, memStore)
-		err = reference.FullSync()
+		reference := lowe.New(auth, memStore)
+		err = reference.FullSync(driveID)
 		if err != nil {
 			if errors.Is(err, ds.ErrDataAnomaly) {
 				fmt.Printf("\n%swarning%s - Changes were propagated but a data anomaly occured during the full sync.\n", colourYellow, colourReset)

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -40,10 +40,11 @@ func setupTest(handler http.HandlerFunc) (*fetcher, *httptest.Server, *mockSleep
 	sleep := &mockSleep{}
 
 	fetch := &fetcher{
-		auth:    &mockAuth{},
-		client:  &http.Client{},
-		baseURL: server.URL,
-		sleep:   sleep.Sleep,
+		auth:       &mockAuth{},
+		client:     &http.Client{},
+		decodeJSON: decodeJSON,
+		baseURL:    server.URL,
+		sleep:      sleep.Sleep,
 	}
 
 	return fetch, server, sleep

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -42,7 +42,6 @@ func setupTest(handler http.HandlerFunc) (*fetcher, *httptest.Server, *mockSleep
 	fetch := &fetcher{
 		auth:    &mockAuth{},
 		client:  &http.Client{},
-		driveID: driveID,
 		baseURL: server.URL,
 		sleep:   sleep.Sleep,
 	}
@@ -118,7 +117,7 @@ func TestDrive(t *testing.T) {
 			fetch, server, _ := setupTest(handler)
 			defer server.Close()
 
-			name, err := fetch.drive()
+			name, err := fetch.drive(driveID)
 			if err != nil {
 				t.Errorf("unexpected error: %s", err.Error())
 				return
@@ -161,7 +160,7 @@ func TestPageToken(t *testing.T) {
 			fetch, server, _ := setupTest(handler)
 			defer server.Close()
 
-			pageToken, err := fetch.pageToken()
+			pageToken, err := fetch.pageToken(driveID)
 			if err != nil {
 				t.Errorf("unexpected error: %s", err.Error())
 				return
@@ -274,7 +273,7 @@ func TestAllContent(t *testing.T) {
 			fetch, server, _ := setupTest(handler)
 			defer server.Close()
 
-			folders, files, err := fetch.allContent()
+			folders, files, err := fetch.allContent(driveID)
 			if err != nil {
 				t.Errorf("AllContent returned an error: %s", err.Error())
 				return
@@ -431,7 +430,7 @@ func TestChangedContent(t *testing.T) {
 			fetch, server, _ := setupTest(handler)
 			defer server.Close()
 
-			diff, err := fetch.changedContent(tc.fixture)
+			diff, err := fetch.changedContent(driveID, tc.fixture)
 			if err != nil {
 				t.Errorf("ChangedContent returned an error: %s", err.Error())
 				return


### PR DESCRIPTION
This pull request adds the options pattern to the Bernard API to override certain default values.

The first four overridable options are:
- Setting a custom HTTP client to re-use connections between Bernard instances and to set a different default timeout.
- Setting the SafeSleep value. This value allows one to sleep between the fetch of the startPageToken and the full sync. As the full sync might lack behind the startPageToken sometimes, setting this value between one and five minutes guarantees no data is lost.
- Global rate-limiting for the fetch layer through the `WithPreRequestHook` option.
- Custom JSON decoding with the `WithJSONDecoder` option.

In addition, this PR introduces a BREAKING CHANGE to the Bernard API. Not only because `bernard.New` now accepts these options, but also because `bernard.New` no longer accepts the driveID parameter. Instead, the driveID must be supplied to the PartialSync and FullSync functions. This allows for better connection re-use when the same authentication and datastore is used across multiple drives.

Closes #7 