### PR TITLE
Old & new state in The Difference Hook

### DIFF
--- a/cmd/bernard/main.go
+++ b/cmd/bernard/main.go
@@ -197,16 +197,16 @@ func printDifference(diff *sqlite.Difference) {
 	// print changed folders
 	if len(diff.ChangedFolders) > 0 {
 		fmt.Println("\nChanged folders:")
-		for _, f := range diff.ChangedFolders {
-			fmt.Printf("%schanged%s - %s - %s\n", colourYellow, colourReset, f.ID, f.Name)
+		for _, d := range diff.ChangedFolders {
+			fmt.Printf("%schanged%s - %s - %s\n", colourYellow, colourReset, d.New.ID, d.New.Name)
 		}
 	}
 
 	// print changed files
 	if len(diff.ChangedFiles) > 0 {
 		fmt.Println("\nChanged files:")
-		for _, f := range diff.ChangedFiles {
-			fmt.Printf("%schanged%s - %s - %s\n", colourYellow, colourReset, f.ID, f.Name)
+		for _, d := range diff.ChangedFiles {
+			fmt.Printf("%schanged%s - %s - %s\n", colourYellow, colourReset, d.New.ID, d.New.Name)
 		}
 	}
 

--- a/datastore/sqlite/hook.go
+++ b/datastore/sqlite/hook.go
@@ -13,12 +13,22 @@ import (
 // between two states.
 type Difference struct {
 	AddedFiles   []ds.File
-	ChangedFiles []ds.File
+	ChangedFiles []FileDifference
 	RemovedFiles []ds.File
 
 	AddedFolders   []ds.Folder
-	ChangedFolders []ds.Folder
+	ChangedFolders []FolderDifference
 	RemovedFolders []ds.Folder
+}
+
+type FolderDifference struct {
+	Old ds.Folder
+	New ds.Folder
+}
+
+type FileDifference struct {
+	Old ds.File
+	New ds.File
 }
 
 // NewDifferencesHook creates a Hook which checks which files and folders
@@ -56,7 +66,7 @@ func (store *Datastore) NewDifferencesHook() (bernard.Hook, *Difference) {
 			// If any of the fields do not align between the old and new state,
 			// then this folder must have been changed.
 			if f.Name != folder.Name || f.Parent != folder.Parent || f.Trashed != folder.Trashed {
-				diff.ChangedFolders = append(diff.ChangedFolders, folder)
+				diff.ChangedFolders = append(diff.ChangedFolders, FolderDifference{Old: f, New: folder})
 			}
 		}
 
@@ -86,7 +96,7 @@ func (store *Datastore) NewDifferencesHook() (bernard.Hook, *Difference) {
 			// If any of the fields do not align between the old and new state,
 			// then this file must have been changed.
 			if f.Name != file.Name || f.Parent != file.Parent || f.Trashed != file.Trashed || f.Size != file.Size || f.MD5 != file.MD5 {
-				diff.ChangedFiles = append(diff.ChangedFiles, file)
+				diff.ChangedFiles = append(diff.ChangedFiles, FileDifference{Old: f, New: file})
 			}
 		}
 

--- a/datastore/sqlite/hook_test.go
+++ b/datastore/sqlite/hook_test.go
@@ -85,10 +85,19 @@ func TestDifferenceHook(t *testing.T) {
 				},
 			},
 			expected: &Difference{
-				ChangedFolders: []ds.Folder{
-					{ID: "A", Name: "new name", Parent: "drive", Trashed: false}, // name
-					{ID: "B", Name: "folder b", Parent: "A", Trashed: false},     // parent
-					{ID: "C", Name: "folder c", Parent: "B", Trashed: true},      // trashed
+				ChangedFolders: []FolderDifference{
+					{ // name
+						Old: ds.Folder{ID: "A", Name: "old name", Parent: "drive", Trashed: false},
+						New: ds.Folder{ID: "A", Name: "new name", Parent: "drive", Trashed: false},
+					},
+					{ // parent
+						Old: ds.Folder{ID: "B", Name: "folder b", Parent: "drive", Trashed: false},
+						New: ds.Folder{ID: "B", Name: "folder b", Parent: "A", Trashed: false},
+					},
+					{ // trashed
+						Old: ds.Folder{ID: "C", Name: "folder c", Parent: "B", Trashed: false},
+						New: ds.Folder{ID: "C", Name: "folder c", Parent: "B", Trashed: true},
+					},
 				},
 			},
 		},
@@ -119,12 +128,27 @@ func TestDifferenceHook(t *testing.T) {
 				},
 			},
 			expected: &Difference{
-				ChangedFiles: []ds.File{
-					{ID: "Z", MD5: "new md5", Name: "file Z", Parent: "drive", Size: 10, Trashed: false}, // md5
-					{ID: "Y", MD5: "YYY md5", Name: "new name", Parent: "A", Size: 20, Trashed: true},    // name
-					{ID: "X", MD5: "XXX md5", Name: "file X", Parent: "drive", Size: 30, Trashed: false}, // parent
-					{ID: "W", MD5: "WWW md5", Name: "file W", Parent: "A", Size: 80, Trashed: false},     // size
-					{ID: "V", MD5: "VVV md5", Name: "file V", Parent: "A", Size: 50, Trashed: false},     // trashed
+				ChangedFiles: []FileDifference{
+					{ // md5
+						Old: ds.File{ID: "Z", MD5: "old md5", Name: "file Z", Parent: "drive", Size: 10, Trashed: false},
+						New: ds.File{ID: "Z", MD5: "new md5", Name: "file Z", Parent: "drive", Size: 10, Trashed: false},
+					},
+					{ // name
+						Old: ds.File{ID: "Y", MD5: "YYY md5", Name: "old name", Parent: "A", Size: 20, Trashed: true},
+						New: ds.File{ID: "Y", MD5: "YYY md5", Name: "new name", Parent: "A", Size: 20, Trashed: true},
+					},
+					{ // parent
+						Old: ds.File{ID: "X", MD5: "XXX md5", Name: "file X", Parent: "A", Size: 30, Trashed: false},
+						New: ds.File{ID: "X", MD5: "XXX md5", Name: "file X", Parent: "drive", Size: 30, Trashed: false},
+					},
+					{ // size
+						Old: ds.File{ID: "W", MD5: "WWW md5", Name: "file W", Parent: "A", Size: 40, Trashed: false},
+						New: ds.File{ID: "W", MD5: "WWW md5", Name: "file W", Parent: "A", Size: 80, Trashed: false},
+					},
+					{ // trashed
+						Old: ds.File{ID: "V", MD5: "VVV md5", Name: "file V", Parent: "A", Size: 50, Trashed: true},
+						New: ds.File{ID: "V", MD5: "VVV md5", Name: "file V", Parent: "A", Size: 50, Trashed: false},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
The Difference Hook previously only provided the latest state of changed files and folders. However, when one wants to use the old data, it had to be re-fetched from the datastore. Causing unnecessary extra calls to the datastore.

This PR provides both the old and new state for the changed files and folders, making unnecessary datastore calls a problem of the past.