### PR TITLE
refactor(datastore): uint64 file size

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -29,7 +29,7 @@ type File struct {
 	Name    string
 	Parent  string
 	Trashed bool
-	Size    int
+	Size    uint64
 	MD5     string
 }
 

--- a/fetch.go
+++ b/fetch.go
@@ -17,7 +17,7 @@ type driveItem struct {
 	Name        string
 	MimeType    string
 	Parents     []string
-	Size        int `json:"size,string"`
+	Size        uint64 `json:"size,string"`
 	MD5Checksum string
 	Trashed     bool
 	DriveID     string


### PR DESCRIPTION
The `datastore.File.Size` can exceed the maximum integer size on 32 bit systems.
This refactor replaces the use of `int` with `uint64` for the exported datastore types.